### PR TITLE
Add support for styling focus for ARIA controls requiring managed focus

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -115,7 +115,11 @@
     <div>
       <input type="file" title="File">
     </div>
-
-
+    <h2>ARIA Controls Requiring Managed Focus</h2>
+    <div role="radiogroup">
+      <div role="radio" tabindex="0">Radio One</div>
+      <div role="radio" tabindex="0">Radio Two</div>
+      <div role="radio" tabindex="0">Radio Three</div>
+    </div>
   </body>
 </html>

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -197,6 +197,13 @@ function init() {
     'datetime-local': true,
   };
 
+  var arrowKeys = {
+    37: true,
+    38: true,
+    39: true,
+    40: true,
+  };
+
   /**
    * Computes whether the given element should automatically trigger the
    * `focus-ring` class being added, i.e. whether it should always match
@@ -245,6 +252,35 @@ function init() {
   }
 
   /**
+   * Validate the key we're handling should result in the application of the
+   * `focus-ring` class.
+   * @param {Event} e
+   * @return {Boolean}
+   */
+  function keyIsValid(e) {
+    var keyCode = e.keyCode;
+    var target = e.target;
+    var type = target.type;
+    var tagName = target.tagName;
+    var isRadioButton = (tagName == 'input' && type == 'radio');
+
+    // By default the browser allows the user to manipulate the selection
+    // (checked state) among a set of radio buttons
+    // (<input type="radio"> each with a different value but the same `name`).
+    // The selection state change also moves focus to the next/previous radio,
+    // so the `focus-ring` class should be applied in this case to maintain
+    // parity with default browser behavior.
+    if (isRadioButton && arrowKeys[keyCode])
+      return true;
+
+    // Tab or Shift + Tab
+    if (keyCode == 9)
+      return true;
+
+    return false;
+  }
+
+  /**
    * On `keyup` add `focus-ring` class if the user pressed Tab and the event
    * target is an element that will likely require interaction via the
    * keyboard (e.g. a text box).
@@ -260,7 +296,7 @@ function init() {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    if (e.keyCode != 9)
+    if (keyIsValid(e))
       return;
 
     var target = e.target;

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -329,10 +329,22 @@ function init() {
 
   var handledMouseDown = false;
 
+  /**
+   * On `mousedown`, keep track of mousedown events.
+   * @param {Event} e
+   */
   function onMouseDown(e) {
     handledMouseDown = true;
   }
 
+  /**
+   * On `focus`, add the `focus-ring` class if:
+   * 1. The focus event was preceded by a keyboard event or was the result
+   *    of an explicit call to focus()
+   * 2. The target of the event was a custom ARIA control requiring managed
+   *    focus.
+   * @param {Event} e
+   */
   function onFocus(e) {
     // Ignore `focus` events preceded by a mousedown so
     // we can be assured the `focus-ring` class is only applied

--- a/dist/focus-ring.js
+++ b/dist/focus-ring.js
@@ -204,6 +204,28 @@ function init() {
     40: true,
   };
 
+  var managedFocusARIARoles = {
+    // parent roles
+    'grid': true,
+    'listbox': true,
+    'menu': true,
+    'menubar': true,
+    'radiogroup': true,
+    'tree': true,
+    'treegrid': true,
+    'tablist': true,
+
+    // descendant roles
+    'option': true,
+    'menuitem': true,
+    'menuitemradio': true,
+    'menuitemcheckbox': true,
+    'radio': true,
+    'tab': true,
+    'treeitem': true,
+    'gridcell': true,
+  };
+
   /**
    * Computes whether the given element should automatically trigger the
    * `focus-ring` class being added, i.e. whether it should always match
@@ -296,13 +318,42 @@ function init() {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    if (keyIsValid(e))
+    if (!keyIsValid(e))
       return;
 
     var target = e.target;
     if (focusTriggersKeyboardModality(target)) {
       addFocusRingClass(target);
     }
+  }
+
+  var handledMouseDown = false;
+
+  function onMouseDown(e) {
+    handledMouseDown = true;
+  }
+
+  function onFocus(e) {
+    // Ignore `focus` events preceded by a mousedown so
+    // we can be assured the `focus-ring` class is only applied
+    // in response to key events or explicit programmatic focus.
+    //
+    // This works because events are fired in the following order:
+    // 1. mousedown
+    // 2. focus
+    // 3. mouseup
+    // 4. click
+    if (handledMouseDown) {
+      handledMouseDown = false;
+      return;
+    }
+
+    // Add the `focus-ring` class in response to focus events for
+    // ARIA controls requiring managed focused
+    var target = e.target;
+    var role = target.getAttribute('role');
+    if (managedFocusARIARoles[role])
+      addFocusRingClass(target);
   }
 
   /**
@@ -348,6 +399,8 @@ function init() {
     }
   }
 
+  document.addEventListener('mousedown', onMouseDown, true);
+  document.addEventListener('focus', onFocus, true);
   document.addEventListener('keyup', onKeyUp, true);
   document.addEventListener('blur', onBlur, true);
   window.addEventListener('focus', onWindowFocus, true);

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -27,6 +27,13 @@ function init() {
     'datetime-local': true,
   };
 
+  var arrowKeys = {
+    37: true,
+    38: true,
+    39: true,
+    40: true,
+  };
+
   /**
    * Computes whether the given element should automatically trigger the
    * `focus-ring` class being added, i.e. whether it should always match
@@ -75,6 +82,35 @@ function init() {
   }
 
   /**
+   * Validate the key we're handling should result in the application of the
+   * `focus-ring` class.
+   * @param {Event} e
+   * @return {Boolean}
+   */
+  function keyIsValid(e) {
+    var keyCode = e.keyCode;
+    var target = e.target;
+    var type = target.type;
+    var tagName = target.tagName;
+    var isRadioButton = (tagName == 'input' && type == 'radio');
+
+    // By default the browser allows the user to manipulate the selection
+    // (checked state) among a set of radio buttons
+    // (<input type="radio"> each with a different value but the same `name`).
+    // The selection state change also moves focus to the next/previous radio,
+    // so the `focus-ring` class should be applied in this case to maintain
+    // parity with default browser behavior.
+    if (isRadioButton && arrowKeys[keyCode])
+      return true;
+
+    // Tab or Shift + Tab
+    if (keyCode == 9)
+      return true;
+
+    return false;
+  }
+
+  /**
    * On `keyup` add `focus-ring` class if the user pressed Tab and the event
    * target is an element that will likely require interaction via the
    * keyboard (e.g. a text box).
@@ -90,7 +126,7 @@ function init() {
     if (e.altKey || e.ctrlKey || e.metaKey)
       return;
 
-    if (e.keyCode != 9)
+    if (keyIsValid(e))
       return;
 
     var target = e.target;

--- a/src/focus-ring.js
+++ b/src/focus-ring.js
@@ -159,10 +159,22 @@ function init() {
 
   var handledMouseDown = false;
 
+  /**
+   * On `mousedown`, keep track of mousedown events.
+   * @param {Event} e
+   */
   function onMouseDown(e) {
     handledMouseDown = true;
   }
 
+  /**
+   * On `focus`, add the `focus-ring` class if:
+   * 1. The focus event was preceded by a keyboard event or was the result
+   *    of an explicit call to focus()
+   * 2. The target of the event was a custom ARIA control requiring managed
+   *    focus.
+   * @param {Event} e
+   */
   function onFocus(e) {
     // Ignore `focus` events preceded by a mousedown so
     // we can be assured the `focus-ring` class is only applied


### PR DESCRIPTION
This PR is a proof of concept and aims to extend `focus-ring` support to [ARIA controls requiring managed focus](https://www.w3.org/TR/wai-aria/roles#managingfocus).

**Goals for this approach were**
- *Opt in*: only extend this support to [ARIA controls requiring managed focus](https://www.w3.org/TR/wai-aria/roles#managingfocus); existing heuristics with respect to when the `focus-ring` class is applied to native HTML controls remain unchanged.
- *Scalable*: support any keyboard or programmatic focus styling as required by the developer implementing the control *AND* support both types of focus management: managed tabIndex or use of [`aria-activedescendant`](https://www.w3.org/TR/wai-aria/roles#aria-activedescendant)
- *With-the-grain*: shouldn't introduce any new or non-standard attributes or practices