### PR TITLE
add support for ShadowDOM WIP

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -1,113 +1,4 @@
 /**
- * Copyright 2017 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
- * source: https://gist.github.com/samthor/7b307408e73784971ef0fcf4a8af6edd#file-shadowlisten-js-L38
- */
-
-/**
- * @fileoverview Listener to provide Shadow DOM focus events, even inside shadow roots
- *
- * Normally, listening for focus with Shadow DOM will just return the top-most 'host' with a shadow
- * root. That may not be a problem! But if you want to find the 'real' focused element...
- *
- * To use this library, add this after the script is included-
- *   document.addEventListener('focus', shadowFocusHandler, true);
- *
- * You can then listen for `-shadow-focus` events, which will return the furthest focused element-
- *   document.addEventListener('-shadow-focus', function(ev) {
- *     console.info('got focused element', ev.detail, '..inside outer-most shadow root', ev.target);
- *   });
- */
-var shadowFocusHandler = (function() {
-  var eventName = '-shadow-focus';
-  var dispatch = function(target) {
-    var args = { composed: true, bubbles: true, detail: target };
-    var customEvent = new CustomEvent(eventName, args);
-    target.dispatchEvent(customEvent);
-  };
-
-  if (!window.WeakSet || !window.ShadowRoot) {
-    return function(event) {
-      dispatch(event.target);
-    };
-  }
-
-  var focusHandlerSet = new WeakSet();
-
-  /**
-   * @param {Node} target to work on
-   * @param {function(!FocusEvent)} callback to invoke on focus change
-   */
-  function _internal(target, callback) {
-    var currentFocus = target; // save real focus
-
-    // #1: get the nearest ShadowRoot
-    while (!(target instanceof ShadowRoot)) {
-      if (!target) {
-        return;
-      }
-      target = target.parentNode;
-    }
-
-    // #2: are we already handling it?
-    if (focusHandlerSet.has(target)) {
-      return;
-    }
-    focusHandlerSet.add(target);
-
-    // #3: setup focus/blur handlers
-    var hostEl = target.host;
-    var focusinHandler = function(ev) {
-      if (ev.target !== currentFocus) {
-        // prevent dup calls for same focus
-        currentFocus = ev.target;
-        callback(ev);
-      }
-    };
-    var blurHandler = function(ev) {
-      hostEl.removeEventListener('blur', blurHandler, false);
-      target.removeEventListener('focusin', focusinHandler, true);
-      focusHandlerSet.delete(target);
-    };
-
-    // #3: add blur handler to host element
-    hostEl.addEventListener('blur', blurHandler, false);
-
-    // #4: add focus handler within shadow root, to observe changes
-    target.addEventListener('focusin', focusinHandler, true);
-
-    // #5: find next parent SR, do it again
-    _internal(target.host, callback);
-  }
-
-  /**
-   * @param {!FocusEvent} event to process
-   */
-  function shadowFocusHandler(event) {
-    var target =
-      (event.composedPath ? event.composedPath()[0] : null) || event.target;
-    _internal(target, shadowFocusHandler);
-    dispatch(target);
-  }
-
-  return shadowFocusHandler;
-})();
-
-/**
  * https://github.com/WICG/focus-ring
  */
 function init() {
@@ -207,6 +98,37 @@ function init() {
     }
 
     hadKeyboardEvent = true;
+  }
+
+  function onKeyUp(e) {
+    var allowedKeys = [
+      9, // TAB
+      37, // LEFT
+      38, // UP
+      39, // RIGHT
+      40 // DOWN
+    ];
+
+    // Ignore keypresses if the user is holding down a modifier key.
+    if (e.altKey || e.ctrlKey || e.metaKey) {
+      return;
+    }
+
+    // Ignore keypresses which aren't related to keyboard navigation.
+    if (allowedKeys.indexOf(e.keyCode) === -1) {
+      return;
+    }
+
+    var target =
+      typeof e.composedPath === 'function'
+        ? e.composedPath()[0]
+        : document.activeElement;
+
+    if (hadKeyboardEvent || focusTriggersKeyboardModality(target)) {
+      target.addEventListener('blur', onBlur, true);
+      addFocusRingClass(target);
+      hadKeyboardEvent = false;
+    }
   }
 
   /**
@@ -342,8 +264,9 @@ function init() {
   }
 
   document.addEventListener('keydown', onKeyDown, true);
-  document.addEventListener('focus', shadowFocusHandler, true);
-  document.addEventListener('-shadow-focus', onFocus, true);
+  document.addEventListener('keyup', onKeyUp, true);
+  document.addEventListener('click', onFocus, true);
+  document.addEventListener('focus', onFocus, true);
   window.addEventListener('focus', onWindowFocus, true);
   window.addEventListener('blur', onWindowBlur, true);
   addInitialPointerMoveListeners();

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -1,4 +1,113 @@
 /**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * source: https://gist.github.com/samthor/7b307408e73784971ef0fcf4a8af6edd#file-shadowlisten-js-L38
+ */
+
+/**
+ * @fileoverview Listener to provide Shadow DOM focus events, even inside shadow roots
+ *
+ * Normally, listening for focus with Shadow DOM will just return the top-most 'host' with a shadow
+ * root. That may not be a problem! But if you want to find the 'real' focused element...
+ *
+ * To use this library, add this after the script is included-
+ *   document.addEventListener('focus', shadowFocusHandler, true);
+ *
+ * You can then listen for `-shadow-focus` events, which will return the furthest focused element-
+ *   document.addEventListener('-shadow-focus', function(ev) {
+ *     console.info('got focused element', ev.detail, '..inside outer-most shadow root', ev.target);
+ *   });
+ */
+var shadowFocusHandler = (function() {
+  var eventName = '-shadow-focus';
+  var dispatch = function(target) {
+    var args = { composed: true, bubbles: true, detail: target };
+    var customEvent = new CustomEvent(eventName, args);
+    target.dispatchEvent(customEvent);
+  };
+
+  if (!window.WeakSet || !window.ShadowRoot) {
+    return function(event) {
+      dispatch(event.target);
+    };
+  }
+
+  var focusHandlerSet = new WeakSet();
+
+  /**
+   * @param {Node} target to work on
+   * @param {function(!FocusEvent)} callback to invoke on focus change
+   */
+  function _internal(target, callback) {
+    var currentFocus = target; // save real focus
+
+    // #1: get the nearest ShadowRoot
+    while (!(target instanceof ShadowRoot)) {
+      if (!target) {
+        return;
+      }
+      target = target.parentNode;
+    }
+
+    // #2: are we already handling it?
+    if (focusHandlerSet.has(target)) {
+      return;
+    }
+    focusHandlerSet.add(target);
+
+    // #3: setup focus/blur handlers
+    var hostEl = target.host;
+    var focusinHandler = function(ev) {
+      if (ev.target !== currentFocus) {
+        // prevent dup calls for same focus
+        currentFocus = ev.target;
+        callback(ev);
+      }
+    };
+    var blurHandler = function(ev) {
+      hostEl.removeEventListener('blur', blurHandler, false);
+      target.removeEventListener('focusin', focusinHandler, true);
+      focusHandlerSet.delete(target);
+    };
+
+    // #3: add blur handler to host element
+    hostEl.addEventListener('blur', blurHandler, false);
+
+    // #4: add focus handler within shadow root, to observe changes
+    target.addEventListener('focusin', focusinHandler, true);
+
+    // #5: find next parent SR, do it again
+    _internal(target.host, callback);
+  }
+
+  /**
+   * @param {!FocusEvent} event to process
+   */
+  function shadowFocusHandler(event) {
+    var target =
+      (event.composedPath ? event.composedPath()[0] : null) || event.target;
+    _internal(target, shadowFocusHandler);
+    dispatch(target);
+  }
+
+  return shadowFocusHandler;
+})();
+
+/**
  * https://github.com/WICG/focus-ring
  */
 function init() {
@@ -112,8 +221,14 @@ function init() {
       return;
     }
 
-    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
-      addFocusRingClass(e.target);
+    var target =
+      typeof e.composedPath === 'function'
+        ? e.composedPath()[0]
+        : document.activeElement;
+
+    if (hadKeyboardEvent || focusTriggersKeyboardModality(target)) {
+      target.addEventListener('blur', onBlur, true);
+      addFocusRingClass(target);
       hadKeyboardEvent = false;
     }
   }
@@ -127,7 +242,13 @@ function init() {
       return;
     }
 
-    removeFocusRingClass(e.target);
+    var target =
+      typeof e.composedPath === 'function'
+        ? e.composedPath()[0]
+        : document.activeElement;
+
+    target.removeEventListener('blur', onBlur, true);
+    removeFocusRingClass(target);
   }
 
   /**
@@ -221,8 +342,8 @@ function init() {
   }
 
   document.addEventListener('keydown', onKeyDown, true);
-  document.addEventListener('focus', onFocus, true);
-  document.addEventListener('blur', onBlur, true);
+  document.addEventListener('focus', shadowFocusHandler, true);
+  document.addEventListener('-shadow-focus', onFocus, true);
   window.addEventListener('focus', onWindowFocus, true);
   window.addEventListener('blur', onWindowBlur, true);
   addInitialPointerMoveListeners();


### PR DESCRIPTION
This PR adds support for using this polyfill in a project that uses shadowDOM.  It was specifically tested using Polymer components.

2 primary changes were required to make this work.  First was a bit of code (placed at the beginning of the file) that allows document level `focus` listeners to listen inside of shadowDOM.  I got that code [here](https://gist.github.com/samthor/7b307408e73784971ef0fcf4a8af6edd#file-shadowlisten-js-L38).  To make the `blur` listener work, I moved the creation of that listener inside the onFocus function.

The second change was to change the onFocus and onBlur functions to use either the composedPath function or document.activeElement as was described [here](https://github.com/WICG/focus-visible/issues/28#issuecomment-296925625)

The CSS required for getting it to work is a bit different than described in the original README.  Specifically, you need to add this rule to any component that contains a focusable element.
```
:focus:not(.focus-visible) {
  outline: 0;
}
```
In the context of shadowDOM, the body level `.js-focus-visible` isn't particularly meaningful.
