### PR TITLE
Add tab switching fix. Fixes #115

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 npm-debug.log
-.vscode
 .DS_Store
 dist

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.rulers": [80]
+}

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -144,14 +144,14 @@ function init() {
   /**
    * If the user changes tabs, keep track of whether or not the previously
    * focused element had .focus-visible.
-   * If the tab becomes active again, the browser will handle calling focus
-   * on the element again (Safari actually calls it twice).
-   * At this point we just need to remind the system whether or not the user
-   * previously used a keyboard to focus the element.
    * @param {Event} e
    */
   function onVisibilityChange(e) {
     if (document.visibilityState == 'hidden') {
+      // If the tab becomes active again, the browser will handle calling focus
+      // on the element (Safari actually calls it twice).
+      // At this point we just need to remind the system whether or not the user
+      // previously used a keyboard to focus the element.
       if (hadFocusVisibleRecently) {
         hadKeyboardEvent = true;
       }

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -141,6 +141,15 @@ function init() {
     }
   }
 
+  /**
+   * If the user changes tabs, keep track of whether or not the previously
+   * focused element had .focus-visible.
+   * If the tab becomes active again, the browser will handle calling focus
+   * on the element again (Safari actually calls it twice).
+   * At this point we just need to remind the system whether or not the user
+   * previously used a keyboard to focus the element.
+   * @param {Event} e
+   */
   function onVisibilityChange(e) {
     if (document.visibilityState == 'hidden') {
       if (hadFocusVisibleRecently) {
@@ -151,9 +160,10 @@ function init() {
   }
 
   /**
-   * Add a group of listeners to detect usage of any pointing devices. These
-   * listeners will be added when the polyfill first loads, and anytime the
-   * window is blurred, so that they are active when the window regains focus.
+   * Add a group of listeners to detect usage of any pointing devices.
+   * These listeners will be added when the polyfill first loads, and anytime
+   * the window is blurred, so that they are active when the window regains
+   * focus.
    */
   function addInitialPointerMoveListeners() {
     document.addEventListener('mousemove', onInitialPointerMove);
@@ -181,9 +191,9 @@ function init() {
 
   /**
    * When the polfyill first loads, assume the user is in keyboard modality.
-   * If any event is received from a pointing device (mouse, pointer, touch),
-   * turn off keyboard modality. This accounts for situations where focus enters
-   * the page from the URL bar.
+   * If any event is received from a pointing device (e.g. mouse, pointer,
+   * touch), turn off keyboard modality.
+   * This accounts for situations where focus enters the page from the URL bar.
    * @param {Event} e
    */
   function onInitialPointerMove(e) {

--- a/test/fixtures/button.html
+++ b/test/fixtures/button.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/change-tabs-always-match.html
+++ b/test/fixtures/change-tabs-always-match.html
@@ -24,7 +24,7 @@
         var newWindow = window.open();
         setTimeout(function() {
           newWindow.close();
-        }, 1000);
+        }, 1500);
       }
       el.onclick = function() {
         openTempWindow();

--- a/test/fixtures/change-tabs-always-match.html
+++ b/test/fixtures/change-tabs-always-match.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>change tabs always match fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body {
+        margin: 20px;
+      }
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: 0;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <input type="text" id="el">
+    <script src="/dist/focus-visible.js"></script>
+    <script>
+      function openTempWindow() {
+        var newWindow = window.open();
+        setTimeout(function() {
+          newWindow.close();
+        }, 500);
+      }
+      el.onclick = function() {
+        openTempWindow();
+      };
+      el.onkeyup = function(e) {
+        if (e.keyCode == 32) {
+          openTempWindow();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/test/fixtures/change-tabs-always-match.html
+++ b/test/fixtures/change-tabs-always-match.html
@@ -24,7 +24,7 @@
         var newWindow = window.open();
         setTimeout(function() {
           newWindow.close();
-        }, 500);
+        }, 1000);
       }
       el.onclick = function() {
         openTempWindow();

--- a/test/fixtures/change-tabs-always-match.html
+++ b/test/fixtures/change-tabs-always-match.html
@@ -9,7 +9,7 @@
         margin: 20px;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/change-tabs-always-match.html
+++ b/test/fixtures/change-tabs-always-match.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>change tabs always match fixture</title>
+    <title>change tabs with focus on element which always matches focus ring fixture</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>

--- a/test/fixtures/change-tabs-sometimes-match.html
+++ b/test/fixtures/change-tabs-sometimes-match.html
@@ -15,7 +15,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/change-tabs-sometimes-match.html
+++ b/test/fixtures/change-tabs-sometimes-match.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>change tabs sometimes match fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body {
+        margin: 20px;
+      }
+      [tabindex] {
+        width: 100px;
+        height: 60px;
+        padding: 3px;
+        border: 1px solid #000;
+      }
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: 0;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <div tabindex="0" id="el">Click me</div>
+    <script src="/dist/focus-visible.js"></script>
+    <script>
+      function openTempWindow() {
+        var newWindow = window.open();
+        setTimeout(function() {
+          newWindow.close();
+        }, 500);
+      }
+      el.onclick = function() {
+        openTempWindow();
+      };
+      el.onkeyup = function(e) {
+        if (e.keyCode == 32) {
+          openTempWindow();
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/test/fixtures/change-tabs-sometimes-match.html
+++ b/test/fixtures/change-tabs-sometimes-match.html
@@ -30,7 +30,7 @@
         var newWindow = window.open();
         setTimeout(function() {
           newWindow.close();
-        }, 1000);
+        }, 1500);
       }
       el.onclick = function() {
         openTempWindow();

--- a/test/fixtures/change-tabs-sometimes-match.html
+++ b/test/fixtures/change-tabs-sometimes-match.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>change tabs sometimes match fixture</title>
+    <title>change tabs with focus on element which matches focus ring only on keyboard focus fixture</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>

--- a/test/fixtures/change-tabs-sometimes-match.html
+++ b/test/fixtures/change-tabs-sometimes-match.html
@@ -30,7 +30,7 @@
         var newWindow = window.open();
         setTimeout(function() {
           newWindow.close();
-        }, 500);
+        }, 1000);
       }
       el.onclick = function() {
         openTempWindow();

--- a/test/fixtures/contenteditable-textbox.html
+++ b/test/fixtures/contenteditable-textbox.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/contenteditable-true.html
+++ b/test/fixtures/contenteditable-true.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/contenteditable.html
+++ b/test/fixtures/contenteditable.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-checkbox.html
+++ b/test/fixtures/input-checkbox.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-color.html
+++ b/test/fixtures/input-color.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-date.html
+++ b/test/fixtures/input-date.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-file.html
+++ b/test/fixtures/input-file.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-number.html
+++ b/test/fixtures/input-number.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-radio-group.html
+++ b/test/fixtures/input-radio-group.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-radio.html
+++ b/test/fixtures/input-radio.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-range.html
+++ b/test/fixtures/input-range.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-submit.html
+++ b/test/fixtures/input-submit.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-text.html
+++ b/test/fixtures/input-text.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/input-time.html
+++ b/test/fixtures/input-time.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/select-multiple.html
+++ b/test/fixtures/select-multiple.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/select-size.html
+++ b/test/fixtures/select-size.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/select.html
+++ b/test/fixtures/select.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/tabindex-negative-one.html
+++ b/test/fixtures/tabindex-negative-one.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/tabindex-one.html
+++ b/test/fixtures/tabindex-one.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/tabindex-zero.html
+++ b/test/fixtures/tabindex-zero.html
@@ -12,7 +12,7 @@
         border: 1px solid #000;
       }
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/fixtures/textarea.html
+++ b/test/fixtures/textarea.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       .js-focus-visible :focus:not(.focus-visible) {
-        outline: 0;
+        outline: none;
       }
       .focus-visible {
         outline: 2px solid red;

--- a/test/specs/change-tabs-always-match.js
+++ b/test/specs/change-tabs-always-match.js
@@ -19,7 +19,7 @@ describe('change tabs, always match if elements should always have focus-visible
     await body.click();
     await body.sendKeys(Key.TAB);
     await el.sendKeys(Key.SPACE);
-    await driver.sleep(2000); // sleep while we open and close a new tab.
+    await driver.sleep(3000); // sleep while we open and close a new tab.
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);
@@ -29,7 +29,7 @@ describe('change tabs, always match if elements should always have focus-visible
   it('should retain .focus-visible if the user switches tabs and an element had .focus-visible from mouse', async function() {
     let el = await driver.findElement(By.css('#el'));
     await el.click();
-    await driver.sleep(2000);
+    await driver.sleep(3000);
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);

--- a/test/specs/change-tabs-always-match.js
+++ b/test/specs/change-tabs-always-match.js
@@ -1,0 +1,38 @@
+const {
+  fixture,
+  matchesKeyboard,
+  matchesMouse,
+  FOCUS_RING_STYLE
+} = require('./helpers');
+const { Key, By } = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
+
+describe('change tabs, always match if elements should always have focus-visible', function() {
+  beforeEach(function() {
+    return fixture('change-tabs-always-match.html');
+  });
+
+  it('should retain .focus-visible if the user switches tabs and an element had .focus-visible from keyboard', async function() {
+    let body = await driver.findElement(By.css('body'));
+    let el = await driver.findElement(By.css('#el'));
+    await body.click();
+    await body.sendKeys(Key.TAB);
+    await el.sendKeys(Key.SPACE);
+    await driver.sleep(2000); // sleep while we open and close a new tab.
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
+  });
+
+  it('should retain .focus-visible if the user switches tabs and an element had .focus-visible from mouse', async function() {
+    let el = await driver.findElement(By.css('#el'));
+    await el.click();
+    await driver.sleep(2000);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
+  });
+});

--- a/test/specs/change-tabs-always-match.js
+++ b/test/specs/change-tabs-always-match.js
@@ -19,7 +19,7 @@ describe('change tabs, always match if elements should always have focus-visible
     await body.click();
     await body.sendKeys(Key.TAB);
     await el.sendKeys(Key.SPACE);
-    await driver.sleep(3000); // sleep while we open and close a new tab.
+    await driver.sleep(4000); // sleep while we open and close a new tab.
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);
@@ -29,7 +29,7 @@ describe('change tabs, always match if elements should always have focus-visible
   it('should retain .focus-visible if the user switches tabs and an element had .focus-visible from mouse', async function() {
     let el = await driver.findElement(By.css('#el'));
     await el.click();
-    await driver.sleep(3000);
+    await driver.sleep(4000);
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);

--- a/test/specs/change-tabs-sometimes-match.js
+++ b/test/specs/change-tabs-sometimes-match.js
@@ -22,7 +22,7 @@ describe('change tabs, only match if elements had focus-visible', function() {
     await body.click();
     await body.sendKeys(Key.TAB);
     await el.sendKeys(Key.SPACE);
-    await driver.sleep(2000); // sleep while we open and close a new tab.
+    await driver.sleep(3000); // sleep while we open and close a new tab.
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);
@@ -32,7 +32,7 @@ describe('change tabs, only match if elements had focus-visible', function() {
   it('should NOT retain .focus-visible if the user switches tabs and an element did not have .focus-visible because it was mouse focused', async function() {
     let el = await driver.findElement(By.css('#el'));
     await el.click();
-    await driver.sleep(2000);
+    await driver.sleep(3000);
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);

--- a/test/specs/change-tabs-sometimes-match.js
+++ b/test/specs/change-tabs-sometimes-match.js
@@ -22,7 +22,7 @@ describe('change tabs, only match if elements had focus-visible', function() {
     await body.click();
     await body.sendKeys(Key.TAB);
     await el.sendKeys(Key.SPACE);
-    await driver.sleep(3000); // sleep while we open and close a new tab.
+    await driver.sleep(4000); // sleep while we open and close a new tab.
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);
@@ -32,7 +32,7 @@ describe('change tabs, only match if elements had focus-visible', function() {
   it('should NOT retain .focus-visible if the user switches tabs and an element did not have .focus-visible because it was mouse focused', async function() {
     let el = await driver.findElement(By.css('#el'));
     await el.click();
-    await driver.sleep(3000);
+    await driver.sleep(4000);
     let actual = await driver.executeScript(`
       return window.getComputedStyle(document.querySelector('#el')).outlineColor
     `);

--- a/test/specs/change-tabs-sometimes-match.js
+++ b/test/specs/change-tabs-sometimes-match.js
@@ -1,0 +1,41 @@
+const {
+  fixture,
+  matchesKeyboard,
+  matchesMouse,
+  FOCUS_RING_STYLE
+} = require('./helpers');
+const { Key, By } = require('selenium-webdriver');
+const expect = require('expect');
+const driver = global.__driver;
+
+describe('change tabs, only match if elements had focus-visible', function() {
+  beforeEach(function() {
+    // Note: For focus to enter the page properly with this fixture I had
+    // to make sure the div had some width/height.
+    // This seems like a geckodriver bug.
+    return fixture('change-tabs-sometimes-match.html');
+  });
+
+  it('should retain .focus-visible if the user switches tabs and an element had .focus-visible from keyboard', async function() {
+    let body = await driver.findElement(By.css('body'));
+    let el = await driver.findElement(By.css('#el'));
+    await body.click();
+    await body.sendKeys(Key.TAB);
+    await el.sendKeys(Key.SPACE);
+    await driver.sleep(2000); // sleep while we open and close a new tab.
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toEqual(FOCUS_RING_STYLE);
+  });
+
+  it('should NOT retain .focus-visible if the user switches tabs and an element did not have .focus-visible because it was mouse focused', async function() {
+    let el = await driver.findElement(By.css('#el'));
+    await el.click();
+    await driver.sleep(2000);
+    let actual = await driver.executeScript(`
+      return window.getComputedStyle(document.querySelector('#el')).outlineColor
+    `);
+    expect(actual).toNotEqual(FOCUS_RING_STYLE);
+  });
+});


### PR DESCRIPTION
This adds a short timeout where we retain the fact that an element just had focus-visible applied.
If the user switches tabs during this interval, we hold on to this information, so when they return we can reapply the focus-visible class to the same element. The browser will actually handle calling focus on the element when we switch back to the previous tab, we just need to provide a signal to remind it that the focus came from the keyboard.

The only issue I've found with this is if you switch tabs _very_ fast in Firefox, it doesn't fire a `visibilitychange` event, so we can't properly reapply the ring. But this is the best I think we can do.

I also removed the onWindowFocus/Blur handlers because they were trying to do this same job but were firing on every focus or blur event which I don't think was intended.

I've added tests for Chrome and Firefox and have manually verified in Safari, Edge, and IE 11.

@alice PTAL