### PR TITLE
Add check for availability of `document` browser variable

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -266,6 +266,6 @@ function onDOMReady(callback) {
   }
 }
 
-if (document !== undefined) {
+if (typeof document !== 'undefined') {
 	onDOMReady(init);
 }

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -267,5 +267,5 @@ function onDOMReady(callback) {
 }
 
 if (typeof document !== 'undefined') {
-	onDOMReady(init);
+  onDOMReady(init);
 }

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -266,4 +266,6 @@ function onDOMReady(callback) {
   }
 }
 
-onDOMReady(init);
+if (document !== undefined) {
+	onDOMReady(init);
+}


### PR DESCRIPTION
Assuming the `document` global variable exists can cause build errors on static pre-renderers. Added a simple `typeof` check before initialization.

Here's a related document on GatsbyJS' website:
https://www.gatsbyjs.org/docs/debugging-html-builds