### PR TITLE
Check if element has `data-focus-visible-added` attribute on blur

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -146,7 +146,10 @@ function init() {
       return;
     }
 
-    if (e.target.classList.contains('focus-visible')) {
+    if (
+      e.target.classList.contains('focus-visible') ||
+      e.target.hasAttribute('data-focus-visible-added')
+    ) {
       // To detect a tab/window switch, we look for a blur event followed
       // rapidly by a visibility change.
       // If we don't see a visibility change within 100ms, it's probably a


### PR DESCRIPTION
This is to solve an issue with React, if the classes are updated on render the `focus-visible` class is removed as React is unaware of it. This could happen when the element should still be focused, one example being a switch component that's toggled with the keyboard updating the classes.