### PR TITLE
Making it works when loaded async or defer

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -257,7 +257,7 @@ function onDOMReady(callback) {
     }
   }
 
-  if (document.readyState === 'complete') {
+  if (['interactive', 'complete'].indexOf(document.readyState) >= 0) {
     callback();
   } else {
     loaded = false;


### PR DESCRIPTION
Testing if `document.readyState` is equal to `'compete'` or `'interactive'` (and not only `'complete'`). So the script can be loaded with an async and/or defer script tag.