### PR TITLE
use proper property name when checking for read-only elements.

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -50,11 +50,11 @@ function init() {
     var type = el.type;
     var tagName = el.tagName;
 
-    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readonly) {
+    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readOnly) {
       return true;
     }
 
-    if (tagName == 'TEXTAREA' && !el.readonly) {
+    if (tagName == 'TEXTAREA' && !el.readOnly) {
       return true;
     }
 


### PR DESCRIPTION
introduced in 66a7ce1fff178662badd02c2fece0c38ac88a3a3 when converting from selectors.