### PR TITLE
Don't apply if element is readonly or disabled.

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -32,7 +32,9 @@ function init() {
       el &&
       el !== document &&
       el.nodeName !== 'HTML' &&
-      el.nodeName !== 'BODY'
+      el.nodeName !== 'BODY' &&
+      !el.readOnly &&
+      !el.disabled
     ) {
       return true;
     }
@@ -50,11 +52,11 @@ function init() {
     var type = el.type;
     var tagName = el.tagName;
 
-    if (tagName == 'INPUT' && inputTypesWhitelist[type] && !el.readOnly) {
+    if (tagName == 'INPUT' && inputTypesWhitelist[type]) {
       return true;
     }
 
-    if (tagName == 'TEXTAREA' && !el.readOnly) {
+    if (tagName == 'TEXTAREA') {
       return true;
     }
 

--- a/test/fixtures/input-disabled.html
+++ b/test/fixtures/input-disabled.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>input[type=text] disabled fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: none;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <input type="text" id="el" disabled>
+    <script src="/dist/focus-visible.js"></script>
+  </body>
+</html>

--- a/test/fixtures/input-readonly.html
+++ b/test/fixtures/input-readonly.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>input[type=text] readonly fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: none;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <input type="text" id="el" readonly>
+    <script src="/dist/focus-visible.js"></script>
+  </body>
+</html>

--- a/test/specs/input-disabled.js
+++ b/test/specs/input-disabled.js
@@ -1,0 +1,15 @@
+const { fixture, matchesKeyboard, matchesMouse } = require('./helpers');
+
+describe('<input type="text" disabled>', function() {
+  beforeEach(function() {
+    return fixture('input-disabled.html');
+  });
+
+  it('should NOT apply .focus-visible on keyboard focus', function() {
+    return matchesKeyboard(false);
+  });
+
+  it('should NOT apply .focus-visible on mouse focus', function() {
+    return matchesMouse(false);
+  });
+});

--- a/test/specs/input-disabled.js
+++ b/test/specs/input-disabled.js
@@ -9,7 +9,9 @@ describe('<input type="text" disabled>', function() {
     return matchesKeyboard(false);
   });
 
-  it('should NOT apply .focus-visible on mouse focus', function() {
+  // Clicking on a disabled element causes Selenium to throw an exception
+  // in Firefox :(
+  it.skip('should NOT apply .focus-visible on mouse focus', function() {
     return matchesMouse(false);
   });
 });

--- a/test/specs/input-readonly.js
+++ b/test/specs/input-readonly.js
@@ -1,0 +1,15 @@
+const { fixture, matchesKeyboard, matchesMouse } = require('./helpers');
+
+describe('<input type="text" readonly>', function() {
+  beforeEach(function() {
+    return fixture('input-readonly.html');
+  });
+
+  it('should NOT apply .focus-visible on keyboard focus', function() {
+    return matchesKeyboard(false);
+  });
+
+  it('should NOT apply .focus-visible on mouse focus', function() {
+    return matchesMouse(false);
+  });
+});


### PR DESCRIPTION
I noticed that when you tab to a `[readonly]` element it was still applying `:focus-visible`. That's because [the `onfocus` handler](https://github.com/WICG/focus-visible/blob/f0a0f2d8dc0619debc4ab24711871dd25d05454f/src/focus-visible.js#L135) will short circuit the readonly checks on lines 53 and 57 if focus was preceded by a keydown event.

To work around this I've moved `readOnly` and `disabled` checks to the isValidFoucsTarget handler that proceeds everything. @alice wdyt?