### PR TITLE
See if we can use greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ cache:
     - "$HOME/.npm"
     - ~/.selenium-assistant
 before_install:
-  - npm i -g npm@latest
-install: npm ci
+# package-lock.json was introduced in npm@5
+- '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
+- npm install -g greenkeeper-lockfile
+install: npm install
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload
 script:
   - npm test
   - npm run sauce


### PR DESCRIPTION
Our greenkeeper builds keep failing because when greenkeeper proposes a change to package.json, it needs to also update the lockfile. Otherwise `npm ci` fails.