### PR TITLE
making focus-visible an es module

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -272,3 +272,13 @@ function onDOMReady(callback) {
 if (typeof document !== 'undefined') {
   onDOMReady(init);
 }
+
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports = init;
+} else (typeof define === 'function' && define.amd) {
+  define([], function() {
+    return init;
+  });
+} else {
+  window.initFocusVisible = init;
+}

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -275,7 +275,7 @@ if (typeof document !== 'undefined') {
 
 if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
   module.exports = init;
-} else (typeof define === 'function' && define.amd) {
+} else if (typeof define === 'function' && define.amd) {
   define([], function() {
     return init;
   });


### PR DESCRIPTION
made focus-visible a module using https://www.matteoagosti.com/blog/2013/02/24/writing-javascript-modules-for-both-browser-and-node/ as a guide

for https://github.com/WICG/focus-visible/issues/163