### PR TITLE
Update README with workaround for class stomping

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ If there are elements which should always have a focus ring shown,
 authors may explicitly add the `focus-visible` class.
 If explicitly added, it will not be removed on `blur`.
 
+Alternatively, if you're using a framework which overwrites your classes ([#179](https://github.com/WICG/focus-visible/issues/179)),
+you can rely on the `data-focus-visible-added` attribute.
+```css
+.js-focus-visible :focus:not([data-focus-visible-added]) {
+  outline: none;
+}
+```
+
 ### How it works
 
 The script uses two heuristics to determine whether the keyboard is being used:


### PR DESCRIPTION
Include mention of using the [data-focus-visible-added] attribute to work around frameworks that stomp on the polyfill class. Fixes #179.

@alice PTAL