### PR TITLE
Fix .eslintrc.js to apply eslint-plugin-es5 rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,6 @@ module.exports = {
   // This is because we don't want/need to use Babel in this project.
   // We specifically DO NOT want ESLint to try to enforce a style guide on us.
   // We use prettier for that.
-  extends: ['prettier'],
-  plugins: ['es5']
+  plugins: ['es5'],
+  extends: ['plugin:es5/no-es2015', 'plugin:es5/no-es2016', 'prettier']
 };


### PR DESCRIPTION
Currently the plugin is loaded but its rules aren't being applied. Add rules so ESLint complains if ES2015 or ES2016 are used. (These are the most current options available; no options for ES2017+ yet. See https://github.com/nkt/eslint-plugin-es5/tree/v1.3.1#usage for details.)