### PR TITLE
chore(package): Fix false positive fail in test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "prepublishOnly": "npm run test",
     "test:server": "http-server . -s",
     "test:selenium": "wait-on http://localhost:8080 && node ./test/index.js",
-    "test": "npm run build && cross-env NODE_ENV=ci concurrently -k \"npm run test:server\" \"npm run test:selenium\"",
-    "sauce": "npm run build && cross-env NODE_ENV=sauce concurrently -k \"npm run test:server\" \"npm run test:selenium\""
+    "test": "npm run build && cross-env NODE_ENV=ci concurrently -k --success last \"npm run test:server\" \"npm run test:selenium\"",
+    "sauce": "npm run build && cross-env NODE_ENV=sauce concurrently -k --success last \"npm run test:server\" \"npm run test:selenium\""
   },
   "lint-staged": {
     "src/focus-visible.js": [


### PR DESCRIPTION
Test were exiting with non-zero for me locally. Probably due to test:server requiring a kill which exited with SIGTERM. Since we're only interested in the exit code of test:selenium we can use https://github.com/kimmobrunfeldt/concurrently/issues/127#issuecomment-364685336