### PR TITLE
Shadow DOM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ this polyfill imperatively to the component's shadow root:
 
 ```javascript
 // Check for the polyfill:
-if (self.applyFocusVisiblePolyfill != null) {
-  self.applyFocusVisiblePolyfill(myComponent.shadowRoot);
+if (window.applyFocusVisiblePolyfill != null) {
+  window.applyFocusVisiblePolyfill(myComponent.shadowRoot);
 }
 ```
 
@@ -120,7 +120,7 @@ In order to act at the right time, you can observe the global
 
 ```javascript
 window.addEventListener('focus-visible-polyfill-ready',
-    () => self.applyFocusVisiblePolyfill(myComponent.shadowRoot),
+    () => window.applyFocusVisiblePolyfill(myComponent.shadowRoot),
     { once:  true });
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,42 @@ You can use a service like [Polyfill.io](https://polyfill.io) to download only t
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Element.prototype.classList"></script>
 ```
 
+### Shadow DOM
+
+It could be very expensive to apply this polyfill automatically to every shadow
+root that is created in a given document, so the polyfill ignores shadow roots
+by default. If you are using Shadow DOM in a component, it is possible to apply
+this polyfill imperatively to the component's shadow root:
+
+```javascript
+// Check for the polyfill:
+if (self.applyFocusVisiblePolyfill != null) {
+  self.applyFocusVisiblePolyfill(myComponent.shadowRoot);
+}
+```
+
+### Lazy-loading
+
+When this polyfill is lazy-loaded, and you are applying the polyfill to a shadow
+root with JavaScript, it is important to know when the polyfill has become
+available before trying to use it.
+
+In order to act at the right time, you can observe the global
+`focus-visible-polyfill-ready` event:
+
+```javascript
+window.addEventListener('focus-visible-polyfill-ready',
+    () => self.applyFocusVisiblePolyfill(myComponent.shadowRoot),
+    { once:  true });
+```
+
+**Important:** this event is _only_ intended to support late application of the
+polyfill in lazy-loading use cases. Do not write code that depends on the event
+firing, as it is timing dependent and only fired once. If you plan to lazy-load
+the polyfill, it is recommended that you check for it synchronously (see example
+above under "Shadow DOM") and listen for the event only if the polyfill isn't
+available yet.
+
 # Backwards compatibility
 Until all browsers ship `:focus-visible` developers will need to use it defensively to avoid accidentally
 removing focus styles in legacy browsers. This is easy to do with the polyfill.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,12 @@
       "integrity": "sha512-6Qnb1gXbp3g1JX9QVJj3A6ORzc9XCyhokxUKaoonHgNXcQhmk8adhotxfkeK8El9TnFeUuH72yI6jQ5nDJKS6w==",
       "dev": true
     },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.10.tgz",
+      "integrity": "sha512-5dzhUhP+h0qMiK0IWb7VNb0OGBoXO3AuI6Qi8t9PoKT50s5L1jv0xnwnLq+cFgPuTB8FLTNP8xIDmyoOsKBy9Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/WICG/focus-visible",
   "devDependencies": {
+    "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.0.0",
     "chromedriver": "^2.38.2",
     "clear-module": "^2.1.0",

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -252,17 +252,18 @@ function applyFocusVisiblePolyfill(scope) {
   scope.addEventListener('focus', onFocus, true);
   scope.addEventListener('blur', onBlur, true);
 
-  if (scope.nodeType === Node.DOCUMENT_NODE) {
-    document.documentElement.classList.add('js-focus-visible');
-
-    // We detect that a node is a ShadowRoot by ensuring that it is a
-    // DocumentFragment and also has a host property. This check covers native
-    // implementation and polyfill implementation transparently.
-  } else if (scope.nodeType === Node.DOCUMENT_FRAGMENT_NODE && scope.host) {
+  // We detect that a node is a ShadowRoot by ensuring that it is a
+  // DocumentFragment and also has a host property. This check covers native
+  // implementation and polyfill implementation transparently. If we only cared
+  // about the native implementation, we could just check if the scope was
+  // an instance of a ShadowRoot.
+  if (scope.nodeType === Node.DOCUMENT_FRAGMENT_NODE && scope.host) {
     // Since a ShadowRoot is a special kind of DocumentFragment, it does not
     // have a root element to add a class to. So, we add this attribute to the
     // host element instead:
     scope.host.setAttribute('data-js-focus-visible', '');
+  } else if (scope.nodeType === Node.DOCUMENT_NODE) {
+    document.documentElement.classList.add('js-focus-visible');
   }
 }
 

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -1,7 +1,11 @@
 /**
- * https://github.com/WICG/focus-visible
+ * Applies the :focus-visible polyfill at the given scope.
+ * A scope in this case is either the top-level Document or a Shadow Root.
+ *
+ * @param {(Document|ShadowRoot)} scope
+ * @see https://github.com/WICG/focus-visible
  */
-function init() {
+function applyFocusVisiblePolyfill(scope) {
   var hadKeyboardEvent = true;
   var hadFocusVisibleRecently = false;
   var hadFocusVisibleRecentlyTimeout = null;
@@ -100,8 +104,8 @@ function init() {
    * @param {Event} e
    */
   function onKeyDown(e) {
-    if (isValidFocusTarget(document.activeElement)) {
-      addFocusVisibleClass(document.activeElement);
+    if (isValidFocusTarget(scope.activeElement)) {
+      addFocusVisibleClass(scope.activeElement);
     }
 
     hadKeyboardEvent = true;
@@ -230,45 +234,57 @@ function init() {
     removeInitialPointerMoveListeners();
   }
 
+  // For some kinds of state, we are interested in changes at the global scope
+  // only. For example, global pointer input, global key presses and global
+  // visibility change should affect the state at every scope:
   document.addEventListener('keydown', onKeyDown, true);
   document.addEventListener('mousedown', onPointerDown, true);
   document.addEventListener('pointerdown', onPointerDown, true);
   document.addEventListener('touchstart', onPointerDown, true);
-  document.addEventListener('focus', onFocus, true);
-  document.addEventListener('blur', onBlur, true);
   document.addEventListener('visibilitychange', onVisibilityChange, true);
+
   addInitialPointerMoveListeners();
 
-  document.body.classList.add('js-focus-visible');
-}
+  // For focus and blur, we specifically care about state changes in the local
+  // scope. This is because focus / blur events that originate from within a
+  // shadow root are not re-dispatched from the host element if it was already
+  // the active element in its own scope:
+  scope.addEventListener('focus', onFocus, true);
+  scope.addEventListener('blur', onBlur, true);
 
-/**
- * Subscription when the DOM is ready
- * @param {Function} callback
- */
-function onDOMReady(callback) {
-  var loaded;
+  if (scope.nodeType === Node.DOCUMENT_NODE) {
+    document.documentElement.classList.add('js-focus-visible');
 
-  /**
-   * Callback wrapper for check loaded state
-   */
-  function load() {
-    if (!loaded) {
-      loaded = true;
-
-      callback();
-    }
-  }
-
-  if (['interactive', 'complete'].indexOf(document.readyState) >= 0) {
-    callback();
-  } else {
-    loaded = false;
-    document.addEventListener('DOMContentLoaded', load, false);
-    window.addEventListener('load', load, false);
+    // We detect that a node is a ShadowRoot by ensuring that it is a
+    // DocumentFragment and also has a host property. This check covers native
+    // implementation and polyfill implementation transparently.
+  } else if (scope.nodeType === Node.DOCUMENT_FRAGMENT_NODE && scope.host) {
+    // Since a ShadowRoot is a special kind of DocumentFragment, it does not
+    // have a root element to add a class to. So, we add this attribute to the
+    // host element instead:
+    scope.host.setAttribute('data-js-focus-visible', '');
   }
 }
 
-if (typeof document !== 'undefined') {
-  onDOMReady(init);
+// Make the polyfill helper globally available. This can be used as a signal to
+// interested libraries that wish to coordinate with the polyfill for e.g.,
+// applying the polyfill to a shadow root:
+window.applyFocusVisiblePolyfill = applyFocusVisiblePolyfill;
+
+// Notify interested libraries of the polyfill's presence, in case the polyfill
+// was loaded lazily:
+var event;
+
+try {
+  event = new CustomEvent('focus-visible-polyfill-ready');
+} catch (error) {
+  // IE11 does not support using CustomEvent as a constructor directly:
+  event = document.createEvent('CustomEvent');
+  event.initCustomEvent('focus-visible-polyfill-ready', false, false, {});
 }
+
+window.dispatchEvent(event);
+
+// Apply the polyfill to the global document, so that no JavaScript coordination
+// is required to use the polyfill in the top-level document:
+applyFocusVisiblePolyfill(document);

--- a/test/fixtures/shadow-dom.html
+++ b/test/fixtures/shadow-dom.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>shadow-dom fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <style>
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: none;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+  </head>
+  <body>
+    <p>An element with a shadow root:</p>
+    <div id="el"></div>
+
+    <template id="shadow-root-template">
+      <style>
+        :host {
+          /* NOTE: We fix the width of the element in order to prevent it from
+           * being accidentally clicked when the test is fixtured. */
+          width: 200px;
+        }
+        :host([data-js-focus-visible]) :focus:not(.focus-visible) {
+          outline: none;
+        }
+        .focus-visible {
+          outline: 2px solid red;
+        }
+      </style>
+      <div id="shadow-el" tabindex="0">Hello</div>
+    </template>
+    <script src="/dist/focus-visible.js"></script>
+    <script>
+      var shadowRootTemplate = document.querySelector('#shadow-root-template');
+      var el = document.querySelector('#el');
+
+      el.attachShadow({ mode: 'open', delegatesFocus: true });
+      el.shadowRoot.appendChild(
+          shadowRootTemplate.content.cloneNode(true));
+
+      // If ShadyCSS is being used, there is no need to apply the polyfill to
+      // the shadow root because the shadow tree is not truly encapsulated:
+      if (self.ShadyCSS == null || self.ShadyCSS.nativeShadow) {
+        applyFocusVisiblePolyfill(el.shadowRoot);
+      }
+    </script>
+  </body>
+</html>

--- a/test/fixtures/shadow-dom.html
+++ b/test/fixtures/shadow-dom.html
@@ -36,18 +36,21 @@
     </template>
     <script src="/dist/focus-visible.js"></script>
     <script>
-      var shadowRootTemplate = document.querySelector('#shadow-root-template');
-      var el = document.querySelector('#el');
+      window.addEventListener('DOMContentLoaded', function() {
+        var shadowRootTemplate = document.querySelector('#shadow-root-template');
 
-      el.attachShadow({ mode: 'open', delegatesFocus: true });
-      el.shadowRoot.appendChild(
-          shadowRootTemplate.content.cloneNode(true));
+        if (self.ShadyCSS != null) {
+          ShadyCSS.prepareTemplate(shadowRootTemplate, 'div');
+        }
 
-      // If ShadyCSS is being used, there is no need to apply the polyfill to
-      // the shadow root because the shadow tree is not truly encapsulated:
-      if (self.ShadyCSS == null || self.ShadyCSS.nativeShadow) {
+        var el = document.querySelector('#el');
+
+        el.attachShadow({ mode: 'open', delegatesFocus: true });
+        el.shadowRoot.appendChild(
+            shadowRootTemplate.content.cloneNode(true));
+
         applyFocusVisiblePolyfill(el.shadowRoot);
-      }
+      }, { once: true });
     </script>
   </body>
 </html>

--- a/test/specs/shadow-dom.js
+++ b/test/specs/shadow-dom.js
@@ -1,0 +1,65 @@
+const { Key, By } = require('selenium-webdriver');
+const {
+  FOCUS_RING_STYLE,
+  fixture,
+  matchesKeyboard,
+  matchesMouse
+} = require('./helpers');
+const expect = require('expect');
+
+async function shadowDescendantMatchesKeyboard(shouldMatch = true) {
+  let driver = global.__driver;
+  let body = await driver.findElement(By.css('body'));
+  await body.sendKeys(Key.TAB);
+  let actual = await driver.executeScript(`
+    var el = document.querySelector('#el');
+    var shadowDescendant = el.shadowRoot.querySelector('#shadow-el');
+    return window.getComputedStyle(shadowDescendant).outlineColor;
+  `);
+  if (shouldMatch) {
+    expect(actual).toEqual(FOCUS_RING_STYLE);
+  } else {
+    expect(actual).toNotEqual(FOCUS_RING_STYLE);
+  }
+}
+
+async function shadowDescendantMatchesMouse(shouldMatch = true) {
+  let driver = global.__driver;
+  let element = await driver.executeScript(`
+    return document.querySelector('#el').shadowRoot.querySelector('#shadow-el');
+  `);
+  await element.click();
+  let actual = await driver.executeScript(`
+    return window.getComputedStyle(document.querySelector('#el')
+        .shadowRoot.querySelector('#shadow-el')).outlineColor;
+  `);
+  if (shouldMatch) {
+    expect(actual).toEqual(FOCUS_RING_STYLE);
+  } else {
+    expect(actual).toNotEqual(FOCUS_RING_STYLE);
+  }
+}
+
+describe('ShadowDOM', function() {
+  beforeEach(function() {
+    return fixture('shadow-dom.html');
+  });
+
+  it('should apply .focus-visible on keyboard focus', async function() {
+    return matchesKeyboard();
+  });
+
+  it('should NOT apply .focus-visible on mouse focus', function() {
+    return matchesMouse(false);
+  });
+
+  describe('focusable elements in shadow', () => {
+    it('should apply .focus-visible on keyboard focus', () => {
+      return shadowDescendantMatchesKeyboard();
+    });
+
+    it('should NOT apply .focus-visible on mouse focus', function() {
+      return shadowDescendantMatchesMouse(false);
+    });
+  });
+});


### PR DESCRIPTION
# Shadow DOM support

This change enables custom elements to coordinate with the polyfill in order to apply it to discrete scopes of the composed tree (such as their shadow roots). Highlights include:

 - The polyfill is now exported to `window` as a function that can be invoked on any `Document|ShadowRoot`
 - The polyfill is automatically, synchronously applied to the top-level `document` when its script runs, preserving the existing behavior
 - Code that wishes to use the polyfill in a `ShadowRoot` can apply it as needed
   - Shadow hosts that have the polyfill applied are decorated with a `data-js-focus-visible` attribute
 - A `focus-visible-polyfill-ready` event is now dispatched on `window` to support lazy loading scenarios (see discussion in #193)

## Example usage as a mixin

In the course of implementing this proposal, I also crafted a mixin to demonstrate how a custom element should coordinate with the polyfill in order to take advantage of `:focus-visible`-like capabilities.

I am **not** proposing to include the mixin in the main project, but it is linked here for future reference:

https://github.com/cdata/focus-visible/blob/fc33395294dd69ad8af70e822e6176a8893816e2/src/custom-element-mixin.js#L1-L49

## Compared to #112 

There is an older WIP proposal (#112) up for consideration that attempts to add transparent support for arbitrary shadow roots. This approach would ultimately require that `focus` and `blur` be observed at every shadow boundary throughout the composed tree in order to work transparently.

The design in the proposal before you expects a Shadow DOM-using component author to opt-in to the polyfill. This allows the polyfill to be applied to Shadow DOM-using components that need it, while avoiding the cost of observing changes in shadow roots that do not know about or do not want to use the polyfill.

## Examples

For the purposes of the following examples:

 - `:focus` elements are styled with purple `color` and `border-color`
 - `:focus-visible` elements receive the default focus ring
 - Elements with shadow roots have `delegatesFocus: true` configured
 - Custom elements apply the [mixin](https://github.com/cdata/focus-visible/blob/fc33395294dd69ad8af70e822e6176a8893816e2/src/custom-element-mixin.js#L1-L49) referenced above to coordinate with the polyfill

This change w/ pointer traversal | This change w/ keyboard traversal
-------------------------------- | ----------------------------------
![focus-not-visible](https://user-images.githubusercontent.com/240083/57001080-b2fb5800-6b6b-11e9-9ac8-a0273cf2dc23.gif) | ![focus-visible](https://user-images.githubusercontent.com/240083/57001081-b68edf00-6b6b-11e9-89a3-3a9052877654.gif)

### Shadow root styling problem

Without this change, it is not possible to use the polyfill from within a shadow root. In the following example, you can see that the top-level document elements can be styled to hide the focus ring when focusing with pointer events, but focusable elements inside of a shadow root still display a focus ring:

Failure to style shadow root-encapsulated elements |
---------------------------------------------------- |
![focus-not-visible-broken](https://user-images.githubusercontent.com/240083/57002222-ba722f80-6b72-11e9-8403-73475e88795e.gif) |

Fixes #193 
Fixes #28 
Fixes #112 