### PR TITLE
IE11: ensure target.nodeName exists

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -222,7 +222,7 @@ function init() {
   function onInitialPointerMove(e) {
     // Work around a Safari quirk that fires a mousemove on <html> whenever the
     // window blurs, even if you're tabbing out of the page. ¯\_(ツ)_/¯
-    if (e.target.nodeName.toLowerCase() === 'html') {
+    if (e.target.nodeName && e.target.nodeName.toLowerCase() === 'html') {
       return;
     }
 


### PR DESCRIPTION
I've seen a few cases where IE11 throws this error:
```
Unable to get property 'toLowerCase' of undefined or null reference
```

See full example on Sentry: https://sentry.io/share/issue/f02ceb35bf504436a21a60c08154341d/

The `e.target.nodeName` in `onInitialPointerMove` is `undefined`, so attempting to read it throws an error.

This pull request adds an extra guard that checks if `nodeName` exists, before calling `toLowerCase()`.