### PR TITLE
Add guard for SSR environments

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -273,25 +273,32 @@ function applyFocusVisiblePolyfill(scope) {
   }
 }
 
-// Make the polyfill helper globally available. This can be used as a signal to
-// interested libraries that wish to coordinate with the polyfill for e.g.,
-// applying the polyfill to a shadow root:
-window.applyFocusVisiblePolyfill = applyFocusVisiblePolyfill;
+// It is important to wrap all references to global window and document in
+// these checks to support server-side rendering use cases
+// @see https://github.com/WICG/focus-visible/issues/199
+if (typeof window !== 'undefined') {
+  // Make the polyfill helper globally available. This can be used as a signal
+  // to interested libraries that wish to coordinate with the polyfill for e.g.,
+  // applying the polyfill to a shadow root:
+  window.applyFocusVisiblePolyfill = applyFocusVisiblePolyfill;
 
-// Notify interested libraries of the polyfill's presence, in case the polyfill
-// was loaded lazily:
-var event;
+  // Notify interested libraries of the polyfill's presence, in case the
+  // polyfill was loaded lazily:
+  var event;
 
-try {
-  event = new CustomEvent('focus-visible-polyfill-ready');
-} catch (error) {
-  // IE11 does not support using CustomEvent as a constructor directly:
-  event = document.createEvent('CustomEvent');
-  event.initCustomEvent('focus-visible-polyfill-ready', false, false, {});
+  try {
+    event = new CustomEvent('focus-visible-polyfill-ready');
+  } catch (error) {
+    // IE11 does not support using CustomEvent as a constructor directly:
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent('focus-visible-polyfill-ready', false, false, {});
+  }
+
+  window.dispatchEvent(event);
 }
 
-window.dispatchEvent(event);
-
-// Apply the polyfill to the global document, so that no JavaScript coordination
-// is required to use the polyfill in the top-level document:
-applyFocusVisiblePolyfill(document);
+if (typeof document !== 'undefined') {
+  // Apply the polyfill to the global document, so that no JavaScript
+  // coordination is required to use the polyfill in the top-level document:
+  applyFocusVisiblePolyfill(document);
+}


### PR DESCRIPTION
This wraps the final interactions with `window` and `document` respectively to guard against the case that they are not there (ostensibly this is the case in SSR scenarios).

Fixes #199 