### PR TITLE
Remove redundant call to clearTimeout

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -168,7 +168,6 @@ function applyFocusVisiblePolyfill(scope) {
       window.clearTimeout(hadFocusVisibleRecentlyTimeout);
       hadFocusVisibleRecentlyTimeout = window.setTimeout(function() {
         hadFocusVisibleRecently = false;
-        window.clearTimeout(hadFocusVisibleRecentlyTimeout);
       }, 100);
       removeFocusVisibleClass(e.target);
     }


### PR DESCRIPTION
I was working on https://github.com/mui-org/material-ui/issues/16976, by luck, the concern was already taking care of in https://github.com/WICG/focus-visible/issues/167. In the process of applying the diff, I have found this strange call to clearTimeout—I believe it's not needed.