### PR TITLE
Set an attribute on the document in addition to the class

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -269,6 +269,7 @@ function applyFocusVisiblePolyfill(scope) {
     scope.host.setAttribute('data-js-focus-visible', '');
   } else if (scope.nodeType === Node.DOCUMENT_NODE) {
     document.documentElement.classList.add('js-focus-visible');
+    document.documentElement.setAttribute('data-js-focus-visible', '')
   }
 }
 

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -269,7 +269,7 @@ function applyFocusVisiblePolyfill(scope) {
     scope.host.setAttribute('data-js-focus-visible', '');
   } else if (scope.nodeType === Node.DOCUMENT_NODE) {
     document.documentElement.classList.add('js-focus-visible');
-    document.documentElement.setAttribute('data-js-focus-visible', '')
+    document.documentElement.setAttribute('data-js-focus-visible', '');
   }
 }
 


### PR DESCRIPTION
Currently only a class is added to the document. This makes it difficult if you are using a  framework which overwrites your classes. This mirrors the solution that is already in place for this same issue. See issue [#179](https://github.com/WICG/focus-visible/issues/179).