### PR TITLE
Marking the repo as host of software development

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -2,5 +2,5 @@
     "group":      ["80485"]
 ,   "contacts":   ["yoavweiss"]
 ,   "shortName":  "modality",
-    "repo-type":  "cg-report"
+    "repo-type":  "tool"
 }


### PR DESCRIPTION
it no longer hosts a CG report afaict