### PR TITLE
Allow referencing package as a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     ]
   },
   "main": "dist/focus-visible.js",
+  "module": "dist/focus-visible.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/WICG/focus-visible.git"


### PR DESCRIPTION
Support importing the polyfill from CDNs like unpkg.com from ES Modules by listing a `module` entry point.