### PR TITLE
fix: Tolerate multiple imports/loads of the script

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -276,7 +276,7 @@ function applyFocusVisiblePolyfill(scope) {
 // It is important to wrap all references to global window and document in
 // these checks to support server-side rendering use cases
 // @see https://github.com/WICG/focus-visible/issues/199
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+if (typeof window !== 'undefined' && typeof document !== 'undefined' && !window.applyFocusVisiblePolyfill) {
   // Make the polyfill helper globally available. This can be used as a signal
   // to interested libraries that wish to coordinate with the polyfill for e.g.,
   // applying the polyfill to a shadow root:
@@ -295,9 +295,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   }
 
   window.dispatchEvent(event);
-}
 
-if (typeof document !== 'undefined') {
   // Apply the polyfill to the global document, so that no JavaScript
   // coordination is required to use the polyfill in the top-level document:
   applyFocusVisiblePolyfill(document);


### PR DESCRIPTION
It may come up that multiple scripts import or load the polyfill into the same document.

In such cases we want to ensure the polyfill only runs once.