### PR TITLE
Support Reach Router by ignoring tabindex="-1"

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -37,6 +37,7 @@ function applyFocusVisiblePolyfill(scope) {
       el !== document &&
       el.nodeName !== 'HTML' &&
       el.nodeName !== 'BODY' &&
+      el.getAttribute('tabindex') !== '-1' &&
       'classList' in el &&
       'contains' in el.classList
     ) {


### PR DESCRIPTION
Reach Router uses a focus wrapper element which is used to contain focus when no other element has it. It gains focus on initial page load, and it is used as a focus target when route is changed in SPA mode to recreate the native browser-like focus management upon switching page.

The wrapper element is rendered as:

```html
<div style="outline:none" tabindex="-1" id="gatsby-focus-wrapper">
```

In general `tabindex="-1"` elements can only be focused without a keyboard so we should probably always ignore them.

## Why is this needed

Without this change `focus-visible` styles are incorrectly applied to Reach Router's focus wrapper element. Also without this change the 100ms timeout in `onBlur` will incorrectly assume user is switching tabs if a client-side redirect occurs upon page loading and as a result element is focused by code as a side-effect. This results into a bug where `focus-visible` toggles style on the focused element upon fresh page load where user has not used the keyboard at all.

## Other thoughts

`onBlur` might need some adjustments to remove the possibility to trigger incorrectly upon focus by code triggering on initial page load. However this proposed change already greatly reduces the chance of focus style triggering incorrectly.