### PR TITLE
hasKeyboardModality: suppress hadKeyboardEvent changes while typing.

### DIFF
--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -9,6 +9,7 @@ function applyFocusVisiblePolyfill(scope) {
   var hadKeyboardEvent = true;
   var hadFocusVisibleRecently = false;
   var hadFocusVisibleRecentlyTimeout = null;
+  var hasKeyboardModality = false;
 
   var inputTypesAllowlist = {
     text: true,
@@ -114,7 +115,9 @@ function applyFocusVisiblePolyfill(scope) {
       addFocusVisibleClass(scope.activeElement);
     }
 
-    hadKeyboardEvent = true;
+    if (!hasKeyboardModality) {
+      hadKeyboardEvent = true;
+    }
   }
 
   /**
@@ -142,7 +145,8 @@ function applyFocusVisiblePolyfill(scope) {
       return;
     }
 
-    if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
+    hasKeyboardModality = focusTriggersKeyboardModality(e.target);
+    if (hadKeyboardEvent || hasKeyboardModality) {
       addFocusVisibleClass(e.target);
     }
   }
@@ -155,6 +159,8 @@ function applyFocusVisiblePolyfill(scope) {
     if (!isValidFocusTarget(e.target)) {
       return;
     }
+
+    hasKeyboardModality = false;
 
     if (
       e.target.classList.contains('focus-visible') ||

--- a/test/fixtures/has-keyboard-modality.html
+++ b/test/fixtures/has-keyboard-modality.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>has keyboard modality fixture</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      .js-focus-visible :focus:not(.focus-visible) {
+        outline: none;
+      }
+      .focus-visible {
+        outline: 2px solid red;
+      }
+    </style>
+    <script>
+      function labelAndFocusButton() {
+        var button = document.querySelector('button');
+        button.innerHTML = document.querySelector('input').value;
+        button.focus();
+        event.preventDefault();
+      }
+    </script>
+  </head>
+  <body>
+    <p>
+      If you <strong>click</strong> into the input, type something and
+      hit Enter to submit the form, the button will not be .focus-visible.
+    </p>
+    <p>
+      If you <strong>tab</strong> into the input, type something and
+      hit Enter, the button <em>will</em> be .focus-visible.
+    </p>
+    <form method="GET" action="#" onsubmit="labelAndFocusButton()">
+      <input type="text" placeholder="Enter button label…" />
+      <button type="submit">Submit</button>
+    </form>
+    <script src="/dist/focus-visible.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR is submitted as a proposed improvement in behavior, and since it might be at variance with existing browser implementations of :focus-visible, it's reasonable to reject it. But I think it's worth discussing whether the minor improvement is desirable, and at least to put this PR in the repo history for anyone who feels .focus-visible should work this way.

In summary, this proposal improves the behavior when using Enter to submit a form causes the focus to shift to another element on the page.

The goal is to match user expectations in a common scenario for Single Page Apps and generally dynamic webpages. Say you have a search field that, when submitted, fetches data via XHR and displays it on the page, calling focus() on the first search result.

With the existing behavior, clicking into the field, typing the query, then hitting Enter will cause that first result to be focus-visible — due to the Enter keydown. That's unexpected for people who mostly use a pointer.

With this change, it's not the Enter keydown that determines focus-visible, it's the method by which you focused the field. If you used Tab to focus the field, the first result will be focus-visible. If you used a pointer to focus the field, it will not.

More details in the commit messages.
